### PR TITLE
Rename __block to __orig_block to avoid OS X build issues

### DIFF
--- a/registration.tmpl.cpp
+++ b/registration.tmpl.cpp
@@ -36,13 +36,13 @@ namespace $ns {
 
 std::shared_ptr<Pothos::Block> factory__$(factory.name)($factory.exported_factory_args)
 {
-    auto __block = $(factory.factory_function_path)($factory.internal_factory_args);
-    auto __pothos_block = makeGrPothosBlock(__block);
+    auto __orig_block = $(factory.factory_function_path)($factory.internal_factory_args);
+    auto __pothos_block = makeGrPothosBlock(__orig_block);
     #if $factory.block_methods
-    auto __block_ref = std::ref(*static_cast<$factory.namespace::$factory.className *>(__block.get()));
+    auto __orig_block_ref = std::ref(*static_cast<$factory.namespace::$factory.className *>(__orig_block.get()));
     #end if
     #for $method in $factory.block_methods
-    __pothos_block->registerCallable("$method.name", Pothos::Callable(&$factory.namespace::$factory.className::$method.name).bind(__block_ref, 0));
+    __pothos_block->registerCallable("$method.name", Pothos::Callable(&$factory.namespace::$factory.className::$method.name).bind(__orig_block_ref, 0));
     #end for
     return __pothos_block;
 }


### PR DESCRIPTION
My compiler seems to have a  __block defined in some built-in headers, which breaks compilation of the templated wrapper code produced by the gr-pothos build process:

```
/Users/meatmanek/Dropbox/code/gr-pothos/build/zeromq_wrapper.cc:85:18: error: expected unqualified-id
    auto __block = pull_msg_source::make(address, timeout);
                 ^
/Users/meatmanek/Dropbox/code/gr-pothos/build/zeromq_wrapper.cc:86:45: error: expected expression
    auto __pothos_block = makeGrPothosBlock(__block);
                                            ^
<built-in>:42:17: note: expanded from here
#define __block __attribute__((__blocks__(byref)))
```

I'm pretty sure this is an [Objective-C++ thing](https://developer.apple.com/library/ios/documentation/Cocoa/Conceptual/Blocks/Articles/bxVariables.html).

This patch simply renames the variable used in the template to avoid the conflict. Maybe there's a better way, like disabling Objective C++ support in the build, but I'm not familiar enough with CMake to make that patch.
